### PR TITLE
remove window minimizing when tiling to bottom

### DIFF
--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -98,7 +98,7 @@ function _IsTiledRight() {
 function _IsTiledToQuadrant() {
     var screenGeometry = _GetScreenGeometry()
     var clientGeometry = _GetClientGeometryOnScreen()
-    if (clientGeometry.width === (screenGeometry.width / 2) && clientGeometry.height === (screenGeometry.height/ 2)) {
+    if (clientGeometry.width === (screenGeometry.width / 2) && clientGeometry.height === (screenGeometry.height / 2)) {
         return true
     }
     return false
@@ -167,7 +167,7 @@ var QuickTileDown = function() {
         workspace.slotWindowQuickTileBottom()
         workspace.slotWindowQuickTileBottom()
     } else {
-        workspace.slotWindowMinimize()
+        workspace.slotWindowQuickTileBottom()
     }
 }
 


### PR DESCRIPTION
Hi!
Really liking this small script!
Saves me ton of time.
Proposing a little change that, well, fits my UX expectations.

What do you think, makes sense?


Old way:
When window is minimized by "meta+downarrow", the focus on window is
lost, and you cannot get the focus back.

The old behavior made "TileDown" scary to use, as you cannot know
if you loose focus on your window or if it gets quick-tiled to bottom.

New way:
Windows never get minimized.
Quick-tiling just tiles the window around as expected.
IMO this better follows principle of least surprise.